### PR TITLE
Add in alerts for PPUD database sync

### DIFF
--- a/docs/database-sync-runbook.md
+++ b/docs/database-sync-runbook.md
@@ -38,7 +38,7 @@ You're looking for a single pod called something like `ppud-replacement-dev-push
 
 If this is NOT running (i.e. it's crashlooping) check the logs for the pod to see if you can find out why (`kubectl -n ppud-replacement-<environment> logs <pod-name>`) and see if you can resolve. If you need help, [#ask-cloud-platform] is your friend.
 
-If pod is there and running correctly, it means we have a metric scraping issue. If you've not diagnosed these in prometheus before, your best bet is to ask for help in [#ask-cloud-platform].
+If the pod is there and running correctly, it means we have a metric scraping issue. If you've not diagnosed these in prometheus before, your best bet is to ask for help in [#ask-cloud-platform].
 
 If the pod is not even present, it means something has gone wrong with the terraform in the [cloud-platform-environments] repo - if you're not familiar with terraform, your best bet is to ask for help in [#ask-cloud-platform].
 

--- a/docs/database-sync-runbook.md
+++ b/docs/database-sync-runbook.md
@@ -1,0 +1,46 @@
+# PPUD Database Sync Runbook
+
+This page contains notes deatiling what the alerts for the PPUD database sync mean and how we can go about resolving things...
+
+## Database Sync Failure
+
+> The PPUD database sync for `<environment>` has been in a failed state for more than XX minutes.
+
+This means that the PPUD database sync (managed by the AWS database migration service) has failed.
+
+To check that this is the case, and to see the reported error message (from the sync), run the following command in the root of this repo (substituting in the correct environment):
+
+```sh
+./scripts/check-ppud-replication.sh -e <environment>
+```
+
+If it's an intermittent issue you can restart the sync job with the following:
+
+```sh
+./scripts/start-ppud-replication.sh -e <environment>
+```
+
+Otherwise we'll need to research the issue and potentially work with Lumen to resolve (if it's an issue their end).
+
+## Database Sync Reporting Failure
+
+> The PPUD database sync check for `<environment>` hasn't reported in for more than XX minutes.
+
+This means that the PPUD database sync may still be functioning properly, the prometheus push gateway we use to report on its progress has failed or prometheus (managed by the cloud platform team) is not scraping its metrics correctly.
+
+First, see if the push gateway is up and running:
+
+```sh
+kubectl -n ppud-replacement-<environment> get pods
+```
+
+You're looking for a single pod called something like `ppud-replacement-dev-pushgateway-prometheus-pushgateway-xxxxxxx`...
+
+If this is NOT running (i.e. it's crashlooping) check the logs for the pod to see if you can find out why (`kubectl -n ppud-replacement-<environment> logs <pod-name>`) and see if you can resolve. If you need help, [#ask-cloud-platform] is your friend.
+
+If pod is there and running correctly, it means we have a metric scraping issue. If you've not diagnosed these in prometheus before, your best bet is to ask for help in [#ask-cloud-platform].
+
+If the pod is not even present, it means something has gone wrong with the terraform in the [cloud-platform-environments] repo - if you're not familiar with terraform, your best bet is to ask for help in [#ask-cloud-platform].
+
+[#ask-cloud-platform]: (https://mojdt.slack.com/archives/C57UPMZLY)
+[cloud-platform-environments]: (https://github.com/ministryofjustice/cloud-platform-environments)

--- a/docs/database-sync-runbook.md
+++ b/docs/database-sync-runbook.md
@@ -1,6 +1,6 @@
 # PPUD Database Sync Runbook
 
-This page contains notes deatiling what the alerts for the PPUD database sync mean and how we can go about resolving things...
+This page contains notes detailing what the alerts for the PPUD database sync mean and how we can go about resolving things...
 
 ## Database Sync Failure
 

--- a/helm_deploy/legacy-ppud-api/templates/prometheusrule.yaml
+++ b/helm_deploy/legacy-ppud-api/templates/prometheusrule.yaml
@@ -1,0 +1,38 @@
+{{- $threshold := 30 }}
+{{- $runbookUrl := "https://github.com/ministryofjustice/legacy-ppud-api/blob/main/docs/database-sync-runbook.md" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "generic-service.fullname" . }}-ppud-sync
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version  }}
+    app: {{ include "generic-service.name" . }}
+    release: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: Helm
+spec:
+  groups:
+    - name: {{ include "generic-service.fullname" . }}-ppud-sync
+      rules:
+        - alert: PPUDDatabaseSyncFailure
+          annotations:
+            message: The PPUD database sync for `{{ .Values.environment }}` has been in a failed state for more than {{ $threshold }} minutes.
+            runbook_url: {{ $runbookUrl }}#database-sync-failure
+          expr: |-
+            min(dms_task_status{namespace="{{ .Release.Namespace }}",job="legacy-ppud-api-database-sync"})
+            OR
+            absent(dms_task_status{namespace="{{ .Release.Namespace }}",job="legacy-ppud-api-database-sync"})
+            < 1
+          for: {{ $threshold }}m
+          labels:
+            severity: {{ .Values.alertSeverity }}
+
+        - alert: PPUDDatabaseSyncReportingFailure
+          annotations:
+            message: The PPUD database sync check for `{{ .Values.environment }}` hasn't reported in for more than {{ $threshold }} minutes.
+            runbook_url: {{ $runbookUrl }}#database-sync-reporting-failure
+          expr: |-
+            absent(dms_task_status{namespace="{{ .Release.Namespace }}",job="legacy-ppud-api-database-sync"}) == 1
+          for: {{ $threshold }}m
+          labels:
+            severity: {{ .Values.alertSeverity }}

--- a/helm_deploy/legacy-ppud-api/values.yaml
+++ b/helm_deploy/legacy-ppud-api/values.yaml
@@ -41,4 +41,7 @@ generic-service:
     cloudplatform-live1-3: "35.177.252.54/32"
 
 generic-prometheus-alerts:
-  targetApplication: legacy-ppud-api
+  targetApplication: &alertTargetApplication legacy-ppud-api
+
+# Values needed for templates within this project
+alertTargetApplication: *alertTargetApplication

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,8 +1,6 @@
 ---
 # Per environment values which override defaults in legacy-ppud-api/values.yaml
 
-environment: dev
-
 generic-service:
   replicaCount: 2
 
@@ -16,7 +14,11 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 
 generic-prometheus-alerts:
-  alertSeverity: ppud-replacement-alerts
+  alertSeverity: &alertSeverity ppud-replacement-alerts
   extraDashboardTags:
     - ppud-replacement
-    - dev
+    - &environment dev
+
+# Values needed for templates within this project
+environment: *environment
+alertSeverity: *alertSeverity

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,8 +1,6 @@
 ---
 # Per environment values which override defaults in legacy-ppud-api/values.yaml
 
-environment: preprod
-
 generic-service:
   replicaCount: 2
 
@@ -16,7 +14,11 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 
 generic-prometheus-alerts:
-  alertSeverity: ppud-replacement-preprod
+  alertSeverity: &alertSeverity ppud-replacement-preprod
   extraDashboardTags:
     - ppud-replacement
-    - pre-prod
+    - &environment pre-prod
+
+# Values needed for templates within this project
+environment: *environment
+alertSeverity: *alertSeverity

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,8 +1,6 @@
 ---
 # Per environment values which override defaults in legacy-ppud-api/values.yaml
 
-environment: prod
-
 generic-service:
   replicaCount: 4
 
@@ -16,7 +14,11 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 
 generic-prometheus-alerts:
-  alertSeverity: ppud-replacement-prod
+  alertSeverity: &alertSeverity ppud-replacement-prod
   extraDashboardTags:
     - ppud-replacement
-    - prod
+    - &environment prod
+
+# Values needed for templates within this project
+environment: *environment
+alertSeverity: *alertSeverity


### PR DESCRIPTION
This configures two alerts, and a runbook explaining what the alerts
mean.

The alerts are:

- If the database sync fails, tell us about it
- If the machinery monitoring the database sync fails, tell us about it

ref PUD-839