### PR TITLE
TECH: log4j2.version to 2.17 for CVE-2021-45105

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,9 @@ configurations {
   testImplementation { exclude(group = "org.junit.vintage") }
 }
 
+// Force log4j2.version to 2.17 for CVE-2021-45105
+project.extensions.extraProperties["log4j2.version"] = "2.17.0"
+
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
 }


### PR DESCRIPTION
Should also cause rebuild to clear CVE-2021-43618 from libgmp10