### PR TITLE
TECH: logback.version to 1.2.9 for CVE-2021-42550

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,8 @@ configurations {
 
 // Force log4j2.version to 2.17 for CVE-2021-45105
 project.extensions.extraProperties["log4j2.version"] = "2.17.0"
+// Force logback.version to 1.2.9 (latest stable) for CVE-2021-42550
+project.extensions.extraProperties["logback.version"] = "1.2.9"
 
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")


### PR DESCRIPTION
TECH: logback.version to 1.2.9 for CVE-2021-42550
Built on branch. 
Assuming builds on main then should also cause rebuild to clear CVE-2021-43618 from libgmp10

 