### PR TITLE
PUD-1454: Enable, but hide prometheus metrics and info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,5 @@ ecr.repo
 .editorconfig
 
 #Helm
-**/Chart.lock
+helm_deploy/*/Chart.lock
+helm_deploy/*/charts/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,6 @@ COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.dev.json /
 COPY scripts /app/scripts
 
 USER 2000
+EXPOSE 8080 8081
 
 ENTRYPOINT ["java", "-javaagent:/app/agent.jar", "-jar", "/app/app.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,10 @@ configurations {
 
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
+  implementation("org.springframework.boot:spring-boot-starter-actuator")
+  implementation("io.micrometer:micrometer-registry-prometheus")
+
+  testImplementation("com.natpryce:hamkrest:1.8.0.1")
 }
 
 tasks {

--- a/helm_deploy/legacy-ppud-api/Chart.yaml
+++ b/helm_deploy/legacy-ppud-api/Chart.yaml
@@ -5,7 +5,7 @@ name: legacy-ppud-api
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 1.1.2
+    version: 1.2.1
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 0.3.0

--- a/helm_deploy/legacy-ppud-api/values.yaml
+++ b/helm_deploy/legacy-ppud-api/values.yaml
@@ -12,6 +12,15 @@ generic-service:
   ingress:
     enabled: false
 
+  livenessProbe:
+    httpGet:
+      path: /health/liveness
+      port: metrics
+  readinessProbe:
+    httpGet:
+      path: /health/readiness
+      port: metrics
+
   # Environment variables to load into the deployment
   env:
     JAVA_OPTS: "-Xmx512m"
@@ -36,6 +45,12 @@ generic-service:
     cloudplatform-live1-1: "35.178.209.113/32"
     cloudplatform-live1-2: "3.8.51.207/32"
     cloudplatform-live1-3: "35.177.252.54/32"
+
+  custommetrics:
+    enabled: true
+    scrapeInterval: 15s
+    metricsPath: /prometheus
+    metricsPort: 8081
 
 generic-prometheus-alerts:
   targetApplication: &alertTargetApplication legacy-ppud-api

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/legacyppudapi/controller/HealthController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/legacyppudapi/controller/HealthController.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.legacyppudapi.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class HealthController() {
+  @GetMapping("/health")
+  fun getHealth(): ResponseEntity<String> = ResponseEntity.ok("OK")
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,9 +33,8 @@ server:
     include-message: always
 
 management:
-  #  TODO: PUD-1377/PUD-1454 - do not expose the metrics and health endpoints publicly?
-#  server:
-#    port: 8081
+  server:
+    port: 8081
   endpoints:
     enabled-by-default: false
     web:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/legacyppudapi/controller/HealthControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/legacyppudapi/controller/HealthControllerTest.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.legacyppudapi.controller
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+class HealthControllerTest {
+  private val underTest = HealthController()
+
+  @Test
+  fun `getHealth returns OK`() {
+    val results = underTest.getHealth()
+
+    assertThat(results.statusCodeValue, equalTo(200))
+    assertThat(results.body, equalTo("OK"))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/legacyppudapi/integration/health/HealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/legacyppudapi/integration/health/HealthCheckTest.kt
@@ -2,11 +2,13 @@ package uk.gov.justice.digital.hmpps.legacyppudapi.integration.health
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
 import uk.gov.justice.digital.hmpps.legacyppudapi.integration.IntegrationTestBase
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.function.Consumer
 
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, properties = ["management.server.port=9999", "server.port=9999"])
 class HealthCheckTest : IntegrationTestBase() {
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/legacyppudapi/integration/health/InfoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/legacyppudapi/integration/health/InfoTest.kt
@@ -2,10 +2,12 @@ package uk.gov.justice.digital.hmpps.legacyppudapi.integration.health
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
 import uk.gov.justice.digital.hmpps.legacyppudapi.integration.IntegrationTestBase
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, properties = ["management.server.port=9998", "server.port=9998"])
 class InfoTest : IntegrationTestBase() {
 
   @Test


### PR DESCRIPTION
This enables prometheus metrics on the application (and configures k8s
to allow them to be scraped), but moves all the actuator endpoints to
port 8081 so they will not be publicly available.

ref PUD-1377 - same issue on `manage-recalls-api`.