### PR TITLE
Fix the OWASP dependency check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,7 @@ workflows:
                 - main
     jobs:
       - hmpps/gradle_owasp_dependency_check:
+          cache_key: v2_1
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - hmpps-common-vars
@@ -159,6 +160,7 @@ workflows:
           context:
             - veracode-credentials
             - hmpps-common-vars
+
   security-weekly:
     triggers:
       - schedule:


### PR DESCRIPTION
Updating the cache key fixes the "Unable to connect to the
dependency-check database" bug.