### PR TITLE
TECH bump gradle-spring-boot to 4.1.5 for CVE-2022-22968

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.3"
-  kotlin("plugin.spring") version "1.6.20"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.5"
+  kotlin("plugin.spring") version "1.6.21"
 }
 
 configurations {


### PR DESCRIPTION
Should allow nightly Security build to pass.